### PR TITLE
raise PDFObjectNotFound for obj_id=0, not AssertionError

### DIFF
--- a/pdfminer3/pdfdocument.py
+++ b/pdfminer3/pdfdocument.py
@@ -667,7 +667,6 @@ class PDFDocument(object):
 
     # can raise PDFObjectNotFound
     def getobj(self, objid):
-        assert objid != 0
         if not self.xrefs:
             raise PDFException('PDFDocument is not initialized')
         log.debug('getobj: objid=%r', objid)


### PR DESCRIPTION
If the object_id == 0, you can continue parsing the document without generating a fatal assertion error.
